### PR TITLE
Separate game play date to the start date and end date

### DIFF
--- a/src/fixtures/init/ansi.sql
+++ b/src/fixtures/init/ansi.sql
@@ -140,7 +140,8 @@ CREATE TABLE "session"
   "replay_hash" varchar(255), -- tenhou game hash, for deduplication
   "table_index" integer, -- table number in tournament
   "orig_link" text, -- original tenhou game link, for access to replay
-  "play_date" timestamp,
+  "start_date" timestamp,
+  "end_date" timestamp,
   "status" varchar(255), -- planned / inprogress / finished
   "intermediate_results" text, -- json-encoded results for in-progress sessions
   foreign key ("event_id") references "event" ("id")

--- a/src/models/Event.php
+++ b/src/models/Event.php
@@ -72,13 +72,13 @@ class EventModel extends Model
                 $ratings[$item->getPlayerId()] = $item->getRating();
             }
         }
-        
+
         return array_map(function ($seat) use (&$ratings) {
             $seat['rating'] = $ratings[$seat['user_id']];
             return $seat;
         }, $seatings);
     }
-    
+
     /**
      * Find out currently playing tables state (for tournaments only)
      * @param integer $eventId
@@ -125,11 +125,11 @@ class EventModel extends Model
                 }, $game->getPlayers())
             ];
         }
-        
+
         return $output;
     }
 
-    
+
     // ------ Last games related -------
 
     /**
@@ -165,7 +165,7 @@ class EventModel extends Model
 
         foreach ($games as $session) {
             $result['games'][$session->getId()] = [
-                'date' => $session->getPlayDate(),
+                'date' => $session->getEndDate(),
                 'replay_link' => $session->getOrigLink(),
                 'players' => array_map('intval', $session->getPlayersIds()),
                 'final_results' => $this->_arrayMapPreserveKeys(function (SessionResultsPrimitive $el) {

--- a/src/primitives/Session.php
+++ b/src/primitives/Session.php
@@ -41,7 +41,8 @@ class SessionPrimitive extends Primitive
         'replay_hash'           => '_replayHash',
         'table_index'           => '_tableIndex',
         'orig_link'             => '_origLink',
-        'play_date'             => '_playDate',
+        'start_date'            => '_startDate',
+        'end_date'              => '_endDate',
         '::session_user'        => '_playersIds', // external many-to-many relation
         'status'                => '_status',
         'intermediate_results'  => '_current',
@@ -56,7 +57,8 @@ class SessionPrimitive extends Primitive
             '_replayHash'   => $this->_stringTransform(true),
             '_tableIndex'   => $this->_integerTransform(true),
             '_origLink'     => $this->_stringTransform(true),
-            '_playDate'     => $this->_stringTransform(true),
+            '_startDate'    => $this->_stringTransform(true),
+            '_endDate'      => $this->_stringTransform(true),
             '_status'       => $this->_stringTransform(true),
             '_id'           => $this->_integerTransform(true),
             '_current'      => [
@@ -121,7 +123,13 @@ class SessionPrimitive extends Primitive
      * Timestamp
      * @var string
      */
-    protected $_playDate;
+    protected $_startDate;
+
+    /**
+     * Timestamp
+     * @var string
+     */
+    protected $_endDate;
 
     /**
      * ordered list of player ids, east to north.
@@ -150,7 +158,7 @@ class SessionPrimitive extends Primitive
     public function __construct(IDb $db)
     {
         parent::__construct($db);
-        $this->_playDate = date('Y-m-d H:i:s'); // may be actualized on restore
+        $this->_startDate = date('Y-m-d H:i:s'); // may be actualized on restore
     }
 
     /**
@@ -209,8 +217,8 @@ class SessionPrimitive extends Primitive
             $db,
             ['status' => (array)$state, 'event_id' => [$eventId]],
             [
-                'limit' => $limit, 'offset' => $offset,
-                'order' => 'desc',  'orderBy' => 'play_date'
+                'limit' => $limit, 'offset'  => $offset,
+                'order' => 'desc', 'orderBy' => 'end_date'
             ]
         );
     }
@@ -311,7 +319,7 @@ class SessionPrimitive extends Primitive
      */
     public function save()
     {
-        $this->_representationalHash = sha1(implode(',', $this->_playersIds) . $this->_playDate);
+        $this->_representationalHash = sha1(implode(',', $this->_playersIds) . $this->_startDate);
         return parent::save();
     }
 
@@ -413,9 +421,27 @@ class SessionPrimitive extends Primitive
     /**
      * @return string
      */
-    public function getPlayDate()
+    public function getStartDate()
     {
-        return $this->_playDate;
+        return $this->_startDate;
+    }
+
+    /**
+     * @param string $date
+     * @return $this
+     */
+    public function setEndDate($date)
+    {
+        $this->_endDate = $date;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndDate()
+    {
+        return $this->_endDate;
     }
 
     /**
@@ -552,7 +578,7 @@ class SessionPrimitive extends Primitive
         if ($isInRedZone) {
             $this->getCurrentState()->forceFinish();
         }
-        
+
         if ($this->getCurrentState()->isFinished()) {
             $success = $success && $this->finish();
         }
@@ -579,7 +605,13 @@ class SessionPrimitive extends Primitive
         if ($this->getStatus() === 'finished') {
             return false;
         }
-        return $this->setStatus('finished')->save() && $this->_finalizeGame();
+
+        $success = $this
+            ->setStatus('finished')
+            ->setEndDate(date('Y-m-d H:i:s'))
+            ->save();
+
+        return $success && $this->_finalizeGame();
     }
 
     /**

--- a/tests/models/InteractiveSessionTest.php
+++ b/tests/models/InteractiveSessionTest.php
@@ -115,6 +115,7 @@ class SessionModelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($sessionPrimitive));
         $this->assertEquals($this->_event->getId(), $sessionPrimitive[0]->getEventId());
         $this->assertEquals('finished', $sessionPrimitive[0]->getStatus());
+        $this->assertNotEquals('', $sessionPrimitive[0]->getEndDate());
     }
 
     public function testAddRoundRon()


### PR DESCRIPTION
Теперь api запоминает когда игра была запущена и когда она закончилась.

![1](https://cloud.githubusercontent.com/assets/475367/24493625/00f14036-1562-11e7-993e-96f1670bbe1e.png)

Для sqllite3 я делал такие миграции (для mysql возможно придется что-то изменить):

```
ALTER TABLE session ADD start_date TEXT;
ALTER TABLE session ADD end_date TEXT;
UPDATE session SET start_date = play_date;
UPDATE session SET end_date = play_date;
```

Для совместимости со старыми данными нужно новым полям добавить значения из play_date, и потом этот столбец можно удалить.